### PR TITLE
Fix data function test

### DIFF
--- a/test/stubs/data-functions/_src/_data/daFunc.js
+++ b/test/stubs/data-functions/_src/_data/daFunc.js
@@ -1,3 +1,3 @@
-export default function (someNumber) {
-	return someNumber * 100
+export default function () {
+	return (someNumber) => someNumber * 100
 }

--- a/test/test-plugin-data-access.js
+++ b/test/test-plugin-data-access.js
@@ -22,17 +22,15 @@ describe('SCENARIO: Global Data', function() {
 	const options	= {
 		configPath: path.resolve(GLOBAL_DATA_PROJECT_PATH, 'eleventy.config.js')
 	}
-	//	@FIXME: macOS-specific
-	const TRASH 	= path.resolve(os.homedir(), '.Trash')
 
 
 	context('GIVEN some global data', function() {
 		before(function() {
 			//	cleanup output from previous test run
 			if (fs.existsSync(output)) {
-				fs.renameSync(
+				fs.rmdirSync(
 					output,
-					path.resolve(TRASH, `_site__${(new Date()).toISOString()}`)
+					{ recursive: true }
 				)
 			}
 		})

--- a/test/test-plugin-data-functions.js
+++ b/test/test-plugin-data-functions.js
@@ -22,18 +22,13 @@ describe.only('SCENARIO: Global Data Function', function() {
 	const options	= {
 		configPath: path.resolve(GLOBAL_DATA_PROJECT_PATH, 'eleventy.config.js')
 	}
-	//	@FIXME: macOS-specific
-	const TRASH 	= path.resolve(os.homedir(), '.Trash')
 
 
 	context('GIVEN a function export from global data', function() {
 		before(function() {
 			//	cleanup output from previous test run
 			if (fs.existsSync(output)) {
-				fs.renameSync(
-					output,
-					path.resolve(TRASH, `_site__${(new Date()).toISOString()}`)
-				)
+                fs.rmdirSync(output, { recursive: true })
 			}
 		})
 

--- a/test/test-plugin-minimal-setup.js
+++ b/test/test-plugin-minimal-setup.js
@@ -46,16 +46,14 @@ describe('SCENARIO: Minimal possible setup', function() {
 		const options	= {
 			configPath: path.resolve(MINIMAL_PROJECT_PATH, 'eleventy.config.js')
 		}
-		//	@FIXME: macOS-specific
-		const TRASH 	= path.resolve(os.homedir(), '.Trash')
 
 
 		context('WHEN we instantiate Eleventy', function(){
 			before(function() {
 				if (fs.existsSync(output)) {
-					fs.renameSync(
+					fs.rmdirSync(
 						output,
-						path.resolve(TRASH, `_site__${(new Date()).toISOString()}`)
+						{ recursive: true }
 					)
 				}
 			})
@@ -82,4 +80,3 @@ describe('SCENARIO: Minimal possible setup', function() {
 })
 
 describe.todo('SCENARIO: Multiple layouts', function() {})
-


### PR DESCRIPTION
The data file needed to export a function that returns a function.

I replaced the macOS-specific TRASH code with `rmdirSync` and added the output directories to .gitignore. I think there’s still something wrong with how I’m running the tests, though, because running <kbd>npx eleventy</kbd> in the stub directories shows me the right results but the tests for those stubs always say Eleventy produced no files, which I confirmed afterwards.

I wasn’t able to get the Eleventy output by passing `ndjson` to `executeBuild`, either.

P.S.: Would you consider adding a .prettierrc.yaml? I had the devil of a time forcing tabs instead of spaces, not to mention maintaining the rest of your style, and I think that might be because Prettier has its own defaults. 😅